### PR TITLE
Update README to include Go installation step for setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Bulk update GitHub project items and fields from a TSV or CSV file.
 
 1. Clone the repo
 2. Create a [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic) with the `project` permissions
-3. Run `make setup` and enter your newly created access token when prompted
+3. Make sure Go in installed on your machine: [Go installation instructions](https://go.dev/doc/install)
+4. Run `make setup` and enter your newly created access token when prompted
 
 ### Running in web app mode
 


### PR DESCRIPTION
### Description
Added a note in the README to ensure Go is installed before running `make setup`, along with a link to the installation guide.

### Changes
- Updated setup instructions in README.

### Motivation
To prevent setup errors for users without Go installed.